### PR TITLE
Reduce allocations in Sauter-Schwab quadrature

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SauterSchwabQuadrature"
 uuid = "535c7bfe-2023-5c1d-b712-654ef9d93a38"
-version = "2.4.2"
+version = "2.5.0"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"

--- a/src/SauterSchwabQuadrature.jl
+++ b/src/SauterSchwabQuadrature.jl
@@ -14,7 +14,7 @@ export CommonFace, CommonEdge, CommonVertex, PositiveDistance
 export CommonFaceQuad, CommonEdgeQuad, CommonVertexQuad
 
 # functions
-export sauterschwab_parameterized, reorder
+export sauterschwab_parameterized, reorder, reorder!
 
 
 

--- a/src/reorder_vertices.jl
+++ b/src/reorder_vertices.jl
@@ -1,4 +1,4 @@
-function reorder(t, s, strat::CommonVertex)
+function reorder!(I, J, K, L, t, s, strat::CommonVertex)
 
     T = eltype(t[1])
     tol = 1e3 * eps(T)
@@ -8,8 +8,6 @@ function reorder(t, s, strat::CommonVertex)
     # Find the permutation P of t and s that make
     # Pt = [P, A1, A2]
     # Ps = [P, B1, B2]
-    I = zeros(Int, 1)
-    J = zeros(Int, 1)
     e = 1
     for i in 1:3
         v = t[i]
@@ -25,14 +23,25 @@ function reorder(t, s, strat::CommonVertex)
         e == 2 && break
     end
 
-    append!(I, setdiff([1, 2, 3], I))
-    append!(J, setdiff([1, 2, 3], J))
+    e = 2
+    for i in 1:3
+        if i != I[1]
+            I[e] = i
+            e += 1
+        end
+    end
+
+    e = 2
+    for j in 1:3
+        if j != J[1]
+            J[e] = j
+            e += 1
+        end
+    end
 
     # # inverse permutations
     # K = indexin([1,2,3], I)
     # L = indexin([1,2,3], J)
-
-    K = zeros(Int, 3)
     for i in 1:3
         for j in 1:3
             if I[j] == i
@@ -42,7 +51,6 @@ function reorder(t, s, strat::CommonVertex)
         end
     end
 
-    L = zeros(Int, 3)
     for i in 1:3
         for j in 1:3
             if J[j] == i
@@ -55,16 +63,22 @@ function reorder(t, s, strat::CommonVertex)
     return I, J, K, L
 end
 
+function reorder(t, s, strat::Union{CommonVertex,CommonEdge,CommonFace})
+    I = Vector{Int}(undef, 3)
+    J = Vector{Int}(undef, 3)
+    K = Vector{Int}(undef, 3)
+    L = Vector{Int}(undef, 3)
+    return reorder!(I, J, K, L, t, s, strat)
+end
 
-function reorder(t, s, strat::CommonEdge)
+
+function reorder!(I, J, K, L, t, s, strat::CommonEdge)
 
     T = eltype(t[1])
     tol = 1e3 * eps(T)
     # tol = 1e5 * eps(T)
     # tol = sqrt(eps(T))
 
-    I = zeros(Int, 3)
-    J = zeros(Int, 3)
     e = 1
     for i in 1:3
         v = t[i]
@@ -78,17 +92,28 @@ function reorder(t, s, strat::CommonEdge)
             end
         end
     end
-    I[3] = setdiff([1, 2, 3], I[1:2])[1]
-    J[3] = setdiff([1, 2, 3], J[1:2])[1]
+    for i in 1:3
+        if i != I[1] && i != I[2]
+            I[3] = i
+            break
+        end
+    end
+    for j in 1:3
+        if j != J[1] && j != J[2]
+            J[3] = j
+            break
+        end
+    end
 
-    I = circshift(I, -1)
-    J = circshift(J, -1)
+    i1, i2, i3 = I[1], I[2], I[3]
+    j1, j2, j3 = J[1], J[2], J[3]
+    I[1], I[2], I[3] = i2, i3, i1
+    J[1], J[2], J[3] = j2, j3, j1
 
     # # inverse permutations
     # K = indexin([1,2,3], I)
     # L = indexin([1,2,3], J)
 
-    K = zeros(Int, 3)
     for i in 1:3
         for j in 1:3
             if I[j] == i
@@ -98,7 +123,6 @@ function reorder(t, s, strat::CommonEdge)
         end
     end
 
-    L = zeros(Int, 3)
     for i in 1:3
         for j in 1:3
             if J[j] == i
@@ -111,8 +135,7 @@ function reorder(t, s, strat::CommonEdge)
     return I, J, K, L
 end
 
-
-function reorder(t, s, strat::CommonFace)
+function reorder!(I, J, K, L, t, s, strat::CommonFace)
 
     T = eltype(t[1])
     tol = 1e3 * eps(T)
@@ -120,8 +143,12 @@ function reorder(t, s, strat::CommonFace)
     # tol = sqrt(eps(T))
 
 
-    I = [1, 2, 3]
-    J = [-1, -1, -1]
+    I[1] = 1
+    I[2] = 2
+    I[3] = 3
+    J[1] = -1
+    J[2] = -1
+    J[3] = -1
     numhits = 0
     for (i, v) in pairs(t)
         for (j, w) in pairs(s)
@@ -133,9 +160,10 @@ function reorder(t, s, strat::CommonFace)
     end
 
     @assert numhits == 3
-    @assert all(J .!= -1)
+    for j in 1:3
+        @assert J[j] != -1
+    end
 
-    K = zeros(Int, 3)
     for i in 1:3
         for j in 1:3
             if I[j] == i
@@ -144,8 +172,6 @@ function reorder(t, s, strat::CommonFace)
             end
         end
     end
-
-    L = zeros(Int, 3)
     for i in 1:3
         for j in 1:3
             if J[j] == i
@@ -158,17 +184,14 @@ function reorder(t, s, strat::CommonFace)
     return I, J, K, L
 end
 
-
 # Find the permutation P of t and s that make
 # Pt = [P, A1, A2, A3]
 # Ps = [P, B1, B2, B3]
-function reorder(t, s, strat::CommonVertexQuad)
+function reorder!(I, J, K, L, t, s, strat::CommonVertexQuad)
     T = eltype(eltype(t))
     T = eltype(t[1])
     tol = 1e3 * eps(T)
 
-    I = zeros(Int, 1)
-    J = zeros(Int, 1)
     e = 1
     for i in 1:4
         v = t[i]
@@ -184,10 +207,20 @@ function reorder(t, s, strat::CommonVertexQuad)
         e == 2 && break
     end
 
-    I = circshift([1, 2, 3, 4], 1 - I[1])
-    J = circshift([1, 2, 3, 4], 1 - J[1])
+    i1 = I[1]
+    j1 = J[1]
+    for k in 1:4
+        I[k] = mod1(i1 + k - 1, 4)
+        J[k] = mod1(j1 + k - 1, 4)
+    end
 
     return I, J, nothing, nothing
+end
+
+function reorder(t, s, strat::Union{CommonVertexQuad,CommonEdgeQuad,CommonFaceQuad})
+    I = Vector{Int}(undef, 4)
+    J = Vector{Int}(undef, 4)
+    return reorder!(I, J, nothing, nothing, t, s, strat)
 end
 
 
@@ -208,12 +241,10 @@ end
 end
 
 
-function reorder(t, s, strat::CommonEdgeQuad)
+function reorder!(I, J, K, L, t, s, strat::CommonEdgeQuad)
     T = eltype(t[1])
     tol = 1e3 * eps(T)
 
-    I = zeros(Int, 2)
-    J = zeros(Int, 2)
     e = 1
     for i in 1:4
         v = t[i]
@@ -229,16 +260,27 @@ function reorder(t, s, strat::CommonEdgeQuad)
         e == 3 && break
     end
 
-    if mod1(I[1] + 1, 4) == I[2]
-        I = circshift([1, 2, 3, 4], 1 - I[1])
+    i1, i2 = I[1], I[2]
+    j1, j2 = J[1], J[2]
+
+    if mod1(i1 + 1, 4) == i2
+        for k in 1:4
+            I[k] = mod1(i1 + k - 1, 4)
+        end
     else
-        I = circshift([4, 3, 2, 1], 1 - (5 - I[1]))
+        for k in 1:4
+            I[k] = mod1(i1 - k + 1, 4)
+        end
     end
 
-    if mod1(J[1] + 1, 4) == J[2]
-        J = circshift([1, 2, 3, 4], 1 - J[1])
+    if mod1(j1 + 1, 4) == j2
+        for k in 1:4
+            J[k] = mod1(j1 + k - 1, 4)
+        end
     else
-        J = circshift([4, 3, 2, 1], 1 - (5 - J[1]))
+        for k in 1:4
+            J[k] = mod1(j1 - k + 1, 4)
+        end
     end
 
     # append!(I, setdiff([1, 2, 3, 4], I))
@@ -264,12 +306,18 @@ end
 end
 
 
-function reorder(t, s, strat::CommonFaceQuad)
+function reorder!(I, J, K, L, t, s, strat::CommonFaceQuad)
     T = eltype(eltype(t))
     tol = 1e3 * eps(T)
 
-    I = [1, 2, 3, 4]
-    J = [-1, -1, -1, -1]
+    I[1] = 1
+    I[2] = 2
+    I[3] = 3
+    I[4] = 4
+    J[1] = -1
+    J[2] = -1
+    J[3] = -1
+    J[4] = -1
     numhits = 0
     for (i, v) in pairs(t)
         for (j, w) in pairs(s)
@@ -281,11 +329,12 @@ function reorder(t, s, strat::CommonFaceQuad)
     end
 
     @assert numhits == 4
-    @assert all(J .!= -1)
+    for j in 1:4
+        @assert J[j] != -1
+    end
 
     return I, J, nothing, nothing
 end
-
 
 @testitem "reorder CommonFaceQuad" begin
     t = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
@@ -362,7 +411,7 @@ function genI(i1, i2)
             return (2, 1, 3)
         end
     end
-    return (1,2,3)
+    return (1, 2, 3)
 end
 
 function reorder_forward(t, s, strat::CommonEdge)
@@ -448,4 +497,3 @@ function reorder_forward(t, s, strat::CommonFace)
     return I, assign(i1, i2, i3, j1, j2, j3)
 end
 reorder_forward(a, b, c) = reorder(a, b, c)[1:2]
-

--- a/src/sauterschwabintegral.jl
+++ b/src/sauterschwabintegral.jl
@@ -40,8 +40,8 @@ end
 
 Compute interaction integrals using the quadrature introduced in [1].
 
-Here, `integrand` is the pull-back of the integrand into the parametric domain 
-of the two triangles that define the integration domain. 
+Here, `integrand` is the pull-back of the integrand into the parametric domain
+of the two triangles that define the integration domain.
 
 The second argument 'strategy' is an object whose type is for triangles one of
 
@@ -56,9 +56,9 @@ and for quadrilaterals one of
 	- `CommonEdgeQuad`
 	- `CommonVertexQuad`
 
-according to the configuration of the two patches defining the domain of integration. 
-The constructors of these classes take a single argument `acc` that defines 
-the number of quadrature points along each of the four axes of the final 
+according to the configuration of the two patches defining the domain of integration.
+The constructors of these classes take a single argument `acc` that defines
+the number of quadrature points along each of the four axes of the final
 rectangular (ξ,η) integration domain (see [1], Ch 5).
 
 Note that here we use for a planar triangle the representation:
@@ -70,8 +70,26 @@ domain and representation is different from the one used in [1].
 
 [1] Sauter. Schwwab, 'Boundary Element Methods', Springer Berlin Heidelberg, 2011
 """
-function sauterschwab_parameterized(integrand, strategy::SauterSchwabStrategy)
+function sauterschwab_parameterized(integrand, strategy::S) where {S <: SauterSchwabStrategy}
 
     qps = strategy.qps
-    sum(w1 * w2 * w3 * w4 * strategy(integrand, η1, η2, η3, ξ) for (η1, w1) in qps, (η2, w2) in qps, (η3, w3) in qps, (ξ, w4) in qps)
+    η1, w1 = qps[1]
+    η2, w2 = qps[1]
+    η3, w3 = qps[1]
+    ξ, w4 = qps[1]
+    acc = zero(w1 * w2 * w3 * w4 * strategy(integrand, η1, η2, η3, ξ))
+
+    for (η1, w1) in qps
+        for (η2, w2) in qps
+            w12 = w1 * w2
+            for (η3, w3) in qps
+                w123 = w12 * w3
+                for (ξ, w4) in qps
+                    acc += w123 * w4 * strategy(integrand, η1, η2, η3, ξ)
+                end
+            end
+        end
+    end
+
+    return acc
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using JuliaFormatter
         include("test_cv_tr.jl")
         include("test_pd_tr.jl")
         include("test_reorder_forward.jl")
+        include("test_reorder_bang.jl")
     end
 
     @testset "Quadrilateral " begin

--- a/test/test_reorder_bang.jl
+++ b/test/test_reorder_bang.jl
@@ -1,0 +1,120 @@
+@testset "reorder!" begin
+    quadPW = SauterSchwabQuadrature._legendre(4, 0, 1)
+    p(x, y, z) = SVector(x, y, z)
+
+    @testset "Triangle" begin
+        t = SVector(
+            p(0.0, 0.0, 0.0),
+            p(1.0, 0.0, 0.0),
+            p(0.0, 1.0, 0.0),
+        )
+
+        cases = (
+            (
+                CommonVertex(quadPW),
+                SVector(
+                    p(0.0, 0.0, 0.0),
+                    p(2.0, 0.0, 0.0),
+                    p(0.0, 2.0, 0.0),
+                ),
+            ),
+            (
+                CommonEdge(quadPW),
+                SVector(
+                    p(0.0, 0.0, 0.0),
+                    p(1.0, 0.0, 0.0),
+                    p(1.0, 1.0, 0.0),
+                ),
+            ),
+            (
+                CommonFace(quadPW),
+                SVector(
+                    p(0.0, 1.0, 0.0),
+                    p(0.0, 0.0, 0.0),
+                    p(1.0, 0.0, 0.0),
+                ),
+            ),
+        )
+
+        for (strat, s) in cases
+            I, J, K, L = reorder(t, s, strat)
+
+            Ip = Vector{Int}(undef, 3)
+            Jp = Vector{Int}(undef, 3)
+            Kp = Vector{Int}(undef, 3)
+            Lp = Vector{Int}(undef, 3)
+            Ip2, Jp2, Kp2, Lp2 = reorder!(Ip, Jp, Kp, Lp, t, s, strat)
+
+            @test Ip2 === Ip
+            @test Jp2 === Jp
+            @test Kp2 === Kp
+            @test Lp2 === Lp
+            @test Ip == I
+            @test Jp == J
+            @test Kp == K
+            @test Lp == L
+
+            reorder!(Ip, Jp, Kp, Lp, t, s, strat)
+            @test (@allocated reorder!(Ip, Jp, Kp, Lp, t, s, strat)) == 0
+        end
+    end
+
+    @testset "Quadrilateral" begin
+        t = SVector(
+            p(0.0, 0.0, 0.0),
+            p(1.0, 0.0, 0.0),
+            p(1.0, 1.0, 0.0),
+            p(0.0, 1.0, 0.0),
+        )
+
+        cases = (
+            (
+                CommonVertexQuad(quadPW),
+                SVector(
+                    p(0.0, -1.0, 0.0),
+                    p(-1.0, -1.0, 0.0),
+                    p(-1.0, 0.0, 0.0),
+                    p(0.0, 0.0, 0.0),
+                ),
+            ),
+            (
+                CommonEdgeQuad(quadPW),
+                SVector(
+                    p(0.0, -1.0, 0.0),
+                    p(1.0, -1.0, 0.0),
+                    p(1.0, 0.0, 0.0),
+                    p(0.0, 0.0, 0.0),
+                ),
+            ),
+            (
+                CommonFaceQuad(quadPW),
+                SVector(
+                    p(1.0, 1.0, 0.0),
+                    p(0.0, 1.0, 0.0),
+                    p(0.0, 0.0, 0.0),
+                    p(1.0, 0.0, 0.0),
+                ),
+            ),
+        )
+
+        for (strat, s) in cases
+            I, J, K, L = reorder(t, s, strat)
+
+            Ip = Vector{Int}(undef, 4)
+            Jp = Vector{Int}(undef, 4)
+            Ip2, Jp2, Kp2, Lp2 = reorder!(Ip, Jp, nothing, nothing, t, s, strat)
+
+            @test Ip2 === Ip
+            @test Jp2 === Jp
+            @test Ip == I
+            @test Jp == J
+            @test K === nothing
+            @test L === nothing
+            @test Kp2 === nothing
+            @test Lp2 === nothing
+
+            reorder!(Ip, Jp, nothing, nothing, t, s, strat)
+            @test (@allocated reorder!(Ip, Jp, nothing, nothing, t, s, strat)) == 0
+        end
+    end
+end


### PR DESCRIPTION
This PR adds `reorder!` functions for Sauter-Schwab vertex reordering.

The new functions write into existing `I`, `J`, `K`, and `L` buffers instead of creating new temporary vectors each time.

The existing `reorder(...)` function is still available. It now calls the new in-place implementation internally.

## Changes

- Add `reorder!(I, J, K, L, t, s, strat)`.
- Keep `reorder(...)` for existing code.
- Change the reordering code to reuse the given buffers.
- Replace some `sum(...)` calls with explicit loops to avoid extra allocations.
- Add tests comparing `reorder!` and `reorder`.
- Bump version to `2.5.0`.

## Motivation

BEAST profiling showed many small allocations from Sauter-Schwab reordering during assembly. Reusing the same buffers avoids these allocations and reduces garbage collection.

A follow-up BEAST PR will use this new `reorder!` API to reuse quadrature buffers during assembly.